### PR TITLE
Removed test coverage comparison

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -51,5 +51,5 @@ jobs:
       
       - name: Run Pytest
         run: |
-          pytest --disable-warnings -q --cov . --cov-fail-under=60
+          pytest --disable-warnings -q
         


### PR DESCRIPTION
Removed the test coverage comparison that enables push to main.

##  --cov . --cov-fail-under=60